### PR TITLE
fix "resize_on_focus" feature and expose it in settings

### DIFF
--- a/ExpandGroup.sublime-settings
+++ b/ExpandGroup.sublime-settings
@@ -3,5 +3,8 @@
     // Put a float between 0 and 0.5
     // The target group will expand to 0 < 0.5 + ratio <= 1
     // Horizontally and Vertically
-    "ratio" : 0.3
+    "ratio" : 0.3,
+
+    // Whether to resize on mouse focus (default true)
+    "resize_on_focus" : true
 }


### PR DESCRIPTION
`resize_on_focus` feature is not working, i.e. when setting it to `false` the resize still happens after clicking by mouse an unfocused group.

Probably that was the reason this feature was not exposed in the default plugin settings file, because it was not working.

So this commit makes that setting to work as expected and it's added to the plugin settings file.